### PR TITLE
Add support for NumPy 2

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -18,9 +18,6 @@ jobs:
 
         - name: Install UV.
           uses: astral-sh/setup-uv@v5
-          with:
-              enable-cache: true
-              cache-dependency-glob: "uv.lock"
 
         - name: Build wheel.
           run:  uv build --wheel

--- a/.github/workflows/test_commit.yml
+++ b/.github/workflows/test_commit.yml
@@ -7,7 +7,7 @@ jobs:
     test:
         strategy:
             matrix:
-                python: ["3.6", "3.11"]
+                python: ["3.6", "3.13"]
         runs-on: ubuntu-20.04
         steps:
 
@@ -21,9 +21,6 @@ jobs:
 
           - name: Install UV.
             uses: astral-sh/setup-uv@v5
-            with:
-                enable-cache: true
-                cache-dependency-glob: "uv.lock"
 
           - name: Install package.
             run:  uv sync

--- a/.github/workflows/test_monthly.yml
+++ b/.github/workflows/test_monthly.yml
@@ -20,9 +20,6 @@ jobs:
 
           - name: Install UV.
             uses: astral-sh/setup-uv@v5
-            with:
-                enable-cache: true
-                cache-dependency-glob: "uv.lock"
 
           - name: Install package.
             run:  uv sync

--- a/kde_diffusion/kde1d.py
+++ b/kde_diffusion/kde1d.py
@@ -7,7 +7,7 @@
 from numpy import array, arange
 from numpy import exp, sqrt, pi as π
 from numpy import ceil, log2
-from numpy import product
+from numpy import prod as product
 from numpy import histogram
 from scipy.fft import dct, idct
 from scipy.optimize import brentq

--- a/kde_diffusion/kde2d.py
+++ b/kde_diffusion/kde2d.py
@@ -8,7 +8,7 @@ from numpy import array, arange
 from numpy import exp, sqrt, pi as π
 from numpy import ceil, log2
 from numpy import ones
-from numpy import product, outer
+from numpy import prod as product, outer
 from numpy import histogram2d
 from scipy.fft import dctn, idctn
 from scipy.optimize import brentq

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ readme = 'PyPI.md'
 
 requires-python = '>= 3.6'
 dependencies = [
-    'NumPy < 2',
+    'NumPy',
     'SciPy',
 ]
 

--- a/verification/kde1d_refactored.py
+++ b/verification/kde1d_refactored.py
@@ -7,7 +7,7 @@
 from numpy import arange
 from numpy import exp, sqrt
 from numpy import pi as π
-from numpy import product
+from numpy import prod as product
 from numpy import histogram
 from scipy.fft import dct, idct
 from scipy.optimize import brentq

--- a/verification/kde1d_reimplemented.py
+++ b/verification/kde1d_reimplemented.py
@@ -10,7 +10,7 @@ from numpy import pi as π
 from numpy import zeros
 from numpy import real
 from numpy import hstack
-from numpy import product
+from numpy import prod as product
 from numpy import unique
 from numpy import histogram
 from numpy import isclose

--- a/verification/kde2d_refactored.py
+++ b/verification/kde2d_refactored.py
@@ -6,7 +6,7 @@
 ########################################
 from numpy import array, arange, ones
 from numpy import exp, sqrt, pi as π
-from numpy import product, outer
+from numpy import prod as product, outer
 from numpy import histogram2d
 from numpy import isclose
 from scipy.fft import dctn, idctn

--- a/verification/kde2d_reimplemented.py
+++ b/verification/kde2d_reimplemented.py
@@ -10,7 +10,7 @@ from numpy import pi as π
 from numpy import ones, zeros
 from numpy import real
 from numpy import vstack
-from numpy import product
+from numpy import prod as product
 from numpy import outer
 from numpy import histogram2d
 from numpy import repeat


### PR DESCRIPTION
The API function `numpy.product` was deprecated in NumPy 1.25 and removed in NumPy 2. It used to be just an alias for `numpy.prod`. Instead, we now alias it ourselves on import.